### PR TITLE
Fixed compilation error in UISink.h

### DIFF
--- a/src/Log/UISink.h
+++ b/src/Log/UISink.h
@@ -21,7 +21,7 @@ protected:
     {
         // msg.payload is the raw string without any formatting
         memory_buf_t formatted;
-        base_sink::formatter_->format(msg, formatted);
+        this->formatter_->format(msg, formatted);
         func(fmt::to_string(formatted).c_str(), msg.level);
     }
 


### PR DESCRIPTION
First of all, thank you for this rendering implementation on bgfx, this is very interesting product to say the least. I'm going to post some changes that i had to make to build it on Linux with GCC (9.2). I don't know if you want to merge them, but i'll leave them here anyway.

This PR is fixing the following compilation error:

```
[ 96%] Building CXX object src/CMakeFiles/Cluster.dir/UI.cpp.o
In file included from /home/alex/projects/Cluster/src/UI.cpp:7:
/home/alex/projects/Cluster/src/Log/UISink.h: In member function ‘virtual void spdlog::ext::clusterui_sink<Mutex, Func>::sink_it_(const spdlog::details::log_msg&)’:
/home/alex/projects/Cluster/src/Log/UISink.h:24:9: error: ‘base_sink’ has not been declared
   24 |         base_sink::formatter_->format(msg, formatted);
      |         ^~~~~~~~~
```