### PR TITLE
Fixed link error in deferred renderer

### DIFF
--- a/src/Renderer/DeferredRenderer.cpp
+++ b/src/Renderer/DeferredRenderer.cpp
@@ -7,6 +7,8 @@
 #include <glm/matrix.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
+constexpr bgfx::TextureFormat::Enum DeferredRenderer::gBufferAttachmentFormats[DeferredRenderer::GBufferAttachment::Count - 1];
+
 DeferredRenderer::DeferredRenderer(const Scene* scene) :
     Renderer(scene),
     pointLightVertexBuffer(BGFX_INVALID_HANDLE),


### PR DESCRIPTION
This PR is fixing the following link error:

```
[ 97%] Linking CXX executable ../Cluster
CMakeFiles/Cluster.dir/Renderer/DeferredRenderer.cpp.o: In function `DeferredRenderer::createGBuffer()':
DeferredRenderer.cpp:(.text+0xe8f): undefined reference to `DeferredRenderer::gBufferAttachmentFormats'
collect2: error: ld returned 1 exit status
```