### PR TITLE
Reduced minimum required CMake version to 3.5

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -10,9 +10,9 @@
 # for setting BGFX_CONFIG_RENDERER_OPENGL
 # need a newer version of bgfx/bigg to take effect
 
-add_compile_definitions(BGFX_CONFIG_RENDERER_OPENGL_MIN_VERSION=43)
-#add_compile_definitions(BGFX_CONFIG_RENDERER_OPENGLES_MIN_VERSION=43)
-#add_compile_definitions(BGFX_CONFIG_RENDERER_OPENGL=43)
+add_definitions(-DBGFX_CONFIG_RENDERER_OPENGL_MIN_VERSION=43)
+#add_definitions(-DBGFX_CONFIG_RENDERER_OPENGLES_MIN_VERSION=43)
+#add_definitions(-DBGFX_CONFIG_RENDERER_OPENGL=43)
 set(BIGG_EXAMPLES OFF CACHE INTERNAL "")
 set(BGFX_BUILD_EXAMPLES OFF CACHE INTERNAL "")
 add_subdirectory(bigg)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.5)
 
 project(cluster CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if(NOT CMAKE_BUILD_TYPE) 
+if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif(NOT CMAKE_BUILD_TYPE)
 


### PR DESCRIPTION
This PR reduces CMake requirement to 3.5. I think it's actually somewhere around 2.8 or 3.0 (as in bgfx.cmake) but i didn't check thus 3.5.