### PR TITLE
Packing PBR texture flags into bitmask instead of using two uniforms

### DIFF
--- a/src/Renderer/PBRShader.h
+++ b/src/Renderer/PBRShader.h
@@ -18,8 +18,7 @@ private:
     bgfx::UniformHandle baseColorFactorUniform;
     bgfx::UniformHandle metallicRoughnessNormalOcclusionFactorUniform;
     bgfx::UniformHandle emissiveFactorUniform;
-    bgfx::UniformHandle hasTextures1Uniform;
-    bgfx::UniformHandle hasTextures2Uniform;
+    bgfx::UniformHandle hasTexturesUniform;
     bgfx::UniformHandle baseColorSampler;
     bgfx::UniformHandle metallicRoughnessSampler;
     bgfx::UniformHandle normalSampler;

--- a/src/Renderer/Shaders/pbr.sh
+++ b/src/Renderer/Shaders/pbr.sh
@@ -16,14 +16,13 @@ SAMPLER2D(s_texEmissive,          SAMPLER_PBR_EMISSIVE);
 uniform vec4 u_baseColorFactor;
 uniform vec4 u_metallicRoughnessNormalOcclusionFactor;
 uniform vec4 u_emissiveFactorVec;
-uniform vec4 u_hasTextures1;
-uniform vec4 u_hasTextures2;
+uniform vec4 u_hasTextures;
 
-#define u_hasBaseColorTexture         (u_hasTextures1.x != 0.0f)
-#define u_hasMetallicRoughnessTexture (u_hasTextures1.y != 0.0f)
-#define u_hasNormalTexture            (u_hasTextures1.z != 0.0f)
-#define u_hasOcclusionTexture         (u_hasTextures1.w != 0.0f)
-#define u_hasEmissiveTexture          (u_hasTextures2.x != 0.0f)
+#define u_hasBaseColorTexture         ((uint(u_hasTextures.x) & (1 << 0)) != 0)
+#define u_hasMetallicRoughnessTexture ((uint(u_hasTextures.x) & (1 << 1)) != 0)
+#define u_hasNormalTexture            ((uint(u_hasTextures.x) & (1 << 2)) != 0)
+#define u_hasOcclusionTexture         ((uint(u_hasTextures.x) & (1 << 3)) != 0)
+#define u_hasEmissiveTexture          ((uint(u_hasTextures.x) & (1 << 4)) != 0)
 
 #define u_metallicRoughnessFactor (u_metallicRoughnessNormalOcclusionFactor.xy)
 #define u_normalScale             (u_metallicRoughnessNormalOcclusionFactor.z)


### PR DESCRIPTION
It seems suboptimal to use two `vec4` uniforms to hold texture flags for PBR when all of them can be packed into a single float, so i packed them into a single float. Still uses whole `vec4` for 5 flags though. Can be potentially jammed into `u_emissiveFactorVec.w` i think.

OpenGL requirement as of now is 4.3, bitwise operations should work since OpenGL 3.1 or so i think, might have got something wrong. Also i tested this only on OpenGL, but i assume other backends should be able to support this as well.