### PR TITLE
Decoupled material reading and material initialization

### DIFF
--- a/src/Renderer/Shaders/pbr.sh
+++ b/src/Renderer/Shaders/pbr.sh
@@ -116,6 +116,8 @@ vec3 pbrEmissive(vec2 texcoord)
     }
 }
 
+PBRMaterial pbrInitMaterial(PBRMaterial mat);
+
 PBRMaterial pbrMaterial(vec2 texcoord)
 {
     PBRMaterial mat;
@@ -130,6 +132,15 @@ PBRMaterial pbrMaterial(vec2 texcoord)
     mat.occlusion = pbrOcclusion(texcoord);
     mat.emissive = pbrEmissive(texcoord);
 
+    mat = pbrInitMaterial(mat);
+
+    return mat;
+}
+
+#endif // READ_MATERIAL
+
+PBRMaterial pbrInitMaterial(PBRMaterial mat)
+{
     // Taken directly from GLTF 2.0 specs
     // this can be precalculated instead of evaluating it in the BRDF for every light
 
@@ -142,8 +153,6 @@ PBRMaterial pbrMaterial(vec2 texcoord)
 
     return mat;
 }
-
-#endif
 
 // gives a new value a (roughness^2)
 float specularAntiAliasing(vec3 N, float a)
@@ -176,7 +185,7 @@ float specularAntiAliasing(vec3 N, float a)
 // and
 // https://learnopengl.com/PBR/Lighting
 
-#define INV_PI 0.3183098861837906715377675267450
+#define INV_PI (0.3183098861837906715377675267450)
 
 // Schlick approximation to Fresnel equation
 vec3 F_Schlick(float VoH, vec3 F0)


### PR DESCRIPTION
What do you think about decoupling material reading and material initialization?

In my application i use different method to load `PBRMaterial`: i don't have all the textures, i'm using different sampler names and predefined values for some material parameters. I've create my own implementation of `pbrMaterial()` (with different name), but i have to copy stuff like

```glsl
const vec3 dielectricSpecular = vec3(0.04, 0.04, 0.04);
```

And other stuff related to updating material parameters from what was loaded.

This doesn't look like a good idea because now i have to track changes in Cluster and update my material loading implementation if any changes occur there. I would love to share material init with Cluster if that's possible, however i'm not sure if this PR is the optimal way to do that, but it's about a minimal patch to Cluster.

I've also added brackets around `INV_PI`.

All of this is not a big deal.